### PR TITLE
V4.1.4

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
     <v-app light>
 
         <!-- Sidebar. -->
-        <sidebar :drawer="drawer"></sidebar>
+        <sidebar :drawer.sync="drawer"></sidebar>
 
 
         <!-- Toolbar. -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,19 +19,20 @@
 </template>
 
 <script>
-    import sidebar from './components/sidebar/sidebar.vue'
-    import toolbar from './components/toolbar/toolbar.vue'
+import sidebar from './components/sidebar/sidebar.vue'
+import toolbar from './components/toolbar/toolbar.vue'
+import { viewportService } from './core/services/viewport-service.js'
 
-    export default {
-        components: {
-            sidebar,
-            toolbar
-        },
+export default {
+    components: {
+        sidebar,
+        toolbar
+    },
 
-        data() {
-            return {
-                drawer: true
-            }
+    data() {
+        return {
+            drawer: viewportService.isMobileViewport() ? false : true
         }
     }
+}
 </script>

--- a/src/components/sidebar/sidebar.vue
+++ b/src/components/sidebar/sidebar.vue
@@ -9,8 +9,7 @@
     <v-navigation-drawer
             class="sidebar"
             fixed
-            :clipped="clipped"
-            v-model="drawer"
+            v-model="proxyDrawerState"
             app
             :style="navigationDrawerStyle"
     >
@@ -40,7 +39,7 @@
             </li>
 
         </v-list>
-    </v-navigation-drawer>
+    </v-navigation-drawer>    
 </template>
 
 <script>
@@ -51,13 +50,36 @@ import searchInput from '../search/search-input.vue'
 import searchResults from '../search/search-results.vue'
 
 export default {
-    props: ['fixed', 'clipped', 'drawer'],
+    props: {
+        drawer: {
+            type: Boolean,
+            required: true
+        }
+    },
 
     data() {
         return {
+            // proxyDrawerState is used to avoid mutating directly the drawer parent prop.
+            // Since v-navigation-drawer doesn't have an onClose hook, we are v-model-ing
+            // this to the drawer and watching for changes so we can emit them back to
+            // the parent. Hackish af.
+            proxyDrawerState: this.drawer,
+
             navigationDrawerStyle: {
                 borderTop: `3px solid ${this.$store.state.core.config.theme_color}`
             }
+        }
+    },
+
+    watch: {
+        proxyDrawerState(val, old) {
+            this.$emit('update:drawer', this.proxyDrawerState)
+        },
+
+        // We need to watch for the prop to change so we can update the local state
+        // with whatever the parent has.
+        drawer(val, old) {
+            this.proxyDrawerState = this.drawer
         }
     },
 

--- a/src/components/toolbar/toolbar.vue
+++ b/src/components/toolbar/toolbar.vue
@@ -16,9 +16,9 @@
 
         <v-tooltip bottom>
             <v-btn icon slot="activator" @click.stop="updateDrawerState">
-                <v-icon>fullscreen</v-icon>
+                <v-icon>menu</v-icon>
             </v-btn>
-            <span>Full screen</span>
+            <span>Navigation</span>
         </v-tooltip>
 
         <v-tooltip bottom>

--- a/src/core/services/viewport-service.js
+++ b/src/core/services/viewport-service.js
@@ -1,0 +1,13 @@
+const VIEWPORT = {
+    MOBILE: {
+        WIDTH: 1264 // Set up by Vuetify.
+    }
+};
+
+const viewportService = {
+    isMobileViewport() {
+        return window.innerWidth < VIEWPORT.MOBILE.WIDTH;
+    }
+};
+
+export { viewportService };


### PR DESCRIPTION
# Description
## Scope
- `src/App.vue`
- `src/components/sidebar/sidebar.vue`
- `src/components/toolbar/toolbar.vue`
- `src/core/services/viewport-service.js`

## What changed
- Fixed an issue with navigation drawer on mobile where we needed to double click to toggle the drawer.
- Updated the label to say "Navigation" instead of "Fullscreen"
